### PR TITLE
Add repositories from organizations the user belong to

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+	"tabWidth": 4,
+	"useTabs": true,
+	"singleQuote": true,
+  "trailingComma": "es5",
+  "jsxSingleQuote": true
+}

--- a/client/src/ApiClient.js
+++ b/client/src/ApiClient.js
@@ -5,104 +5,114 @@ import { setContext } from 'apollo-link-context';
 import { gql } from 'apollo-boost';
 
 const GRAPHQL_ENDPOINT =
-	JSON.parse(localStorage.getItem('enterpriseUrl')) ||
-	'https://api.github.com/graphql';
+  JSON.parse(localStorage.getItem('enterpriseUrl')) ||
+  'https://api.github.com/graphql';
 
 const cache = new InMemoryCache();
 const link = new createHttpLink({ uri: `${GRAPHQL_ENDPOINT}` });
 
 const authLink = setContext((_, { headers }) => {
-	return {
-		headers: {
-			...headers,
-			authorization: localStorage.getItem('token')
-				? `bearer ${localStorage.getItem('token')}`
-				: '',
-		},
-	};
+  return {
+    headers: {
+      ...headers,
+      authorization: localStorage.getItem('token')
+        ? `bearer ${localStorage.getItem('token')}`
+        : ''
+    }
+  };
 });
 
 export const client = new ApolloClient({
-	cache,
-	link: authLink.concat(link),
+  cache,
+  link: authLink.concat(link)
 });
-
-export const GET_PRS = gql`
-	query PRinfo($login: String!) {
-		user(login: $login) {
-			id
-			repositories(first: 30, orderBy: { field: NAME, direction: ASC }) {
-				nodes {
-					id
+const repositoriesFragment = `
+repositories(first: 30, orderBy: { field: UPDATED_AT, direction: DESC }) {
+	nodes {
+		id
+		name
+		pullRequests(
+			last: 20
+			states: OPEN
+			orderBy: { field: UPDATED_AT, direction: ASC }
+		) {
+			nodes {
+				id
+				title
+				createdAt
+				updatedAt
+				state
+				url
+				author {
+					... on User {
+						id
+						name
+						email
+						avatarUrl
+						login
+					}
+				}
+				repository {
 					name
-					pullRequests(
-						last: 100
-						orderBy: { field: CREATED_AT, direction: ASC }
-					) {
-						nodes {
-							id
-							title
-							createdAt
-							updatedAt
-							state
-							url
-							author {
-								... on User {
-									id
-									name
-									email
-									avatarUrl
-									login
-								}
-							}
-							repository {
-								name
-								nameWithOwner
-								url
+					nameWithOwner
+					url
+					id
+				}
+				assignees(first: 10) {
+					nodes {
+						name
+						email
+						avatarUrl
+						login
+					}
+				}
+				reviews(first: 10) {
+					nodes {
+						author {
+							... on User {
 								id
-							}
-							assignees(first: 10) {
-								nodes {
-									name
-									email
-									avatarUrl
-									login
-								}
-							}
-							reviews(first: 10) {
-								nodes {
-									author {
-										... on User {
-											id
-											name
-											email
-											avatarUrl
-											login
-										}
-									}
-									state
-									createdAt
-									updatedAt
-								}
+								name
+								email
+								avatarUrl
+								login
 							}
 						}
+						state
+						createdAt
+						updatedAt
 					}
 				}
 			}
 		}
 	}
-`;
+}`;
 
-export const GET_REPOS = gql`
-	query getRepos($login: String!) {
+export const GET_PRS = gql`
+	query PRinfo($login: String!) {
 		user(login: $login) {
 			id
-			repositories(first: 100) {
+			${repositoriesFragment}
+			organizations (first: 5) {
+				totalCount
 				nodes {
-					id
-					nameWithOwner
+					${repositoriesFragment}
 				}
 			}
 		}
+
 	}
+`;
+
+export const GET_REPOS = gql`
+  query getRepos($login: String!) {
+    user(login: $login) {
+      id
+      repositories(first: 100) {
+        nodes {
+          id
+          nameWithOwner
+        }
+      }
+    }
+  }
 `;

--- a/client/src/ApiClient.js
+++ b/client/src/ApiClient.js
@@ -5,26 +5,26 @@ import { setContext } from 'apollo-link-context';
 import { gql } from 'apollo-boost';
 
 const GRAPHQL_ENDPOINT =
-  JSON.parse(localStorage.getItem('enterpriseUrl')) ||
-  'https://api.github.com/graphql';
+	JSON.parse(localStorage.getItem('enterpriseUrl')) ||
+	'https://api.github.com/graphql';
 
 const cache = new InMemoryCache();
 const link = new createHttpLink({ uri: `${GRAPHQL_ENDPOINT}` });
 
 const authLink = setContext((_, { headers }) => {
-  return {
-    headers: {
-      ...headers,
-      authorization: localStorage.getItem('token')
-        ? `bearer ${localStorage.getItem('token')}`
-        : ''
-    }
-  };
+	return {
+		headers: {
+			...headers,
+			authorization: localStorage.getItem('token')
+				? `bearer ${localStorage.getItem('token')}`
+				: '',
+		},
+	};
 });
 
 export const client = new ApolloClient({
-  cache,
-  link: authLink.concat(link)
+	cache,
+	link: authLink.concat(link),
 });
 const repositoriesFragment = `
 repositories(first: 30, orderBy: { field: UPDATED_AT, direction: DESC }) {
@@ -104,15 +104,15 @@ export const GET_PRS = gql`
 `;
 
 export const GET_REPOS = gql`
-  query getRepos($login: String!) {
-    user(login: $login) {
-      id
-      repositories(first: 100) {
-        nodes {
-          id
-          nameWithOwner
-        }
-      }
-    }
-  }
+	query getRepos($login: String!) {
+		user(login: $login) {
+			id
+			repositories(first: 100) {
+				nodes {
+					id
+					nameWithOwner
+				}
+			}
+		}
+	}
 `;

--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -1,113 +1,86 @@
-import React, { useState, useEffect } from "react";
-import cx from "classnames";
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { fas } from "@fortawesome/free-solid-svg-icons";
-import { useQuery } from "@apollo/react-hooks";
-import "./Dashboard.css";
-import PrList from "../PrList/PrList";
-import { GET_PRS, GET_REPOS } from "../ApiClient";
-import Filter from "../Filter/Filter";
-import { mergePRs, filterByRepos } from "./utils";
+import React, { useState, useEffect } from 'react';
+import cx from 'classnames';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+import { useQuery } from '@apollo/react-hooks';
+import './Dashboard.css';
+import PrList from '../PrList/PrList';
+import { GET_PRS, GET_REPOS } from '../ApiClient';
+import Filter from '../Filter/Filter';
+import { mergePRs, filterByRepos } from './utils';
 
 library.add(fas);
 
 function Dashboard({ className, token, username }) {
-	const classnames = cx('Dashboard', className);
-	const [credentials, setCredentials] = useState({});
-	const [pinnedItems, setPinnedItems] = useState(
-		localStorage.getItem('pinnedItems')
-			? JSON.parse(localStorage.getItem('pinnedItems'))
-			: []
-	);
-	const [selectedRepos, setSelectedRepos] = useState(
-		localStorage.getItem('selectedRepos')
-			? JSON.parse(localStorage.getItem('selectedRepos'))
-			: []
-	);
+  const [pinnedItems, setPinnedItems] = useState(
+    localStorage.getItem('pinnedItems')
+      ? JSON.parse(localStorage.getItem('pinnedItems'))
+      : []
+  );
+  const [selectedRepos, setSelectedRepos] = useState(
+    localStorage.getItem('selectedRepos')
+      ? JSON.parse(localStorage.getItem('selectedRepos'))
+      : []
+  );
+  const { loading, data, error } = useQuery(GET_PRS, {
+    variables: {
+      login: `${username}`
+    }
+    // pollInterval: 40000, //todo uncomment
+  });
 
-	useEffect(() => {
-		setCredentials({ token, username });
-	}, []);
+  const {
+    loading: reposLoading,
+    data: reposData,
+    error: reposError
+  } = useQuery(GET_REPOS, {
+    variables: {
+      login: `${username}`
+    }
+  });
 
-	const { loading, data, error } = useQuery(GET_PRS, {
-		variables: {
-			login: `${credentials.username}`,
-		},
-		// pollInterval: 40000, //todo uncomment
-	});
+  let options = [];
 
-	const {
-		loading: reposLoading,
-		data: reposData,
-		error: reposError,
-	} = useQuery(GET_REPOS, {
-		variables: {
-			login: `${credentials.username}`,
-		},
-	});
+  if (reposData) {
+    options = reposData.user.repositories.nodes.map(element => {
+      return { value: element.id, label: element.nameWithOwner };
+    });
+  }
 
-	let options = [];
+  if (error) return <p>Error</p>; // todo make an error page
+  if (loading) return <p>loading</p>; //todo add stylying
 
-	if (reposData) {
-		options = reposData.user.repositories.nodes.map(element => {
-			return { value: element.id, label: element.nameWithOwner };
-		});
-	}
+  const allPRs = data ? mergePRs(data) : [];
+  const filteredByRepos = filterByRepos(allPRs, selectedRepos);
 
-	if (error) return <p>Error</p>; // todo make an error page
-	if (loading) return <p>loading</p>; //todo add stylying
+  const notPinned = filteredByRepos.filter(
+    element => !pinnedItems.includes(element.id)
+  );
+  const pinned = filteredByRepos.filter(element =>
+    pinnedItems.includes(element.id)
+  );
+  const prs = [...pinned, ...notPinned];
 
-	let resultCall = [];
-
-	if (data) {
-		resultCall = data.user.repositories.nodes
-			.map(element => {
-				return element.pullRequests;
-			})
-			.map(element => {
-				return element.nodes;
-			})
-			.reduce((acc, element) => {
-				return acc.concat(element);
-			}, []);
-
-		if (Array.isArray(selectedRepos) && selectedRepos.length > 0) {
-			resultCall = resultCall.filter(element =>
-				selectedRepos.some(repo => repo.value === element.repository.id)
-			);
-		}
-	}
-
-	let notPinned = resultCall
-		.filter(element => !pinnedItems.includes(element.id))
-		.sort((a, b) => a.createdAt - b.createdAt);
-
-	let pinned = resultCall
-		.filter(element => pinnedItems.includes(element.id))
-		.sort((a, b) => a.createdAt - b.createdAt);
-
-	let prs = [...pinned, ...notPinned];
-
-	return (
-		<div className='Dashboard'>
-			<div className='Dashboard-title'>Your PRs dashboard</div>
-			<Filter
-				options={options}
-				className='Dashboard-filter'
-				value={selectedRepos}
-				placeholder='Select your repos...'
-				onChange={value => {
-					setSelectedRepos(value);
-					localStorage.setItem('selectedRepos', JSON.stringify(selectedRepos));
-				}}
-			/>
-			<PrList
-				prs={prs}
-				setPinnedItems={setPinnedItems}
-				className={'Dashboard-list'}
-			/>
-		</div>
-	);
+  return (
+    <div className={cx('Dashboard', className)}>
+      <div className="Dashboard-title">Your PRs dashboard</div>
+      <Filter
+        options={options}
+        className="Dashboard-filter"
+        value={selectedRepos}
+        placeholder="Select your repos..."
+        onChange={value => {
+          setSelectedRepos(value);
+          localStorage.setItem('selectedRepos', JSON.stringify(selectedRepos));
+        }}
+      />
+      <PrList
+        prs={prs}
+        setPinnedItems={setPinnedItems}
+        className={'Dashboard-list'}
+      />
+    </div>
+  );
 }
 
 export default Dashboard;

--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -1,12 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import './Dashboard.css';
-import PrList from '../PrList/PrList';
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { fas } from '@fortawesome/free-solid-svg-icons';
-import { useQuery } from '@apollo/react-hooks';
-import { GET_PRS, GET_REPOS } from '../ApiClient';
-import Filter from '../Filter/Filter';
-import cx from 'classnames';
+import React, { useState, useEffect } from "react";
+import cx from "classnames";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { fas } from "@fortawesome/free-solid-svg-icons";
+import { useQuery } from "@apollo/react-hooks";
+import "./Dashboard.css";
+import PrList from "../PrList/PrList";
+import { GET_PRS, GET_REPOS } from "../ApiClient";
+import Filter from "../Filter/Filter";
+import { mergePRs, filterByRepos } from "./utils";
 
 library.add(fas);
 

--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -12,75 +12,78 @@ import { mergePRs, filterByRepos } from './utils';
 library.add(fas);
 
 function Dashboard({ className, token, username }) {
-  const [pinnedItems, setPinnedItems] = useState(
-    localStorage.getItem('pinnedItems')
-      ? JSON.parse(localStorage.getItem('pinnedItems'))
-      : []
-  );
-  const [selectedRepos, setSelectedRepos] = useState(
-    localStorage.getItem('selectedRepos')
-      ? JSON.parse(localStorage.getItem('selectedRepos'))
-      : []
-  );
-  const { loading, data, error } = useQuery(GET_PRS, {
-    variables: {
-      login: `${username}`
-    }
-    // pollInterval: 40000, //todo uncomment
-  });
+	const [pinnedItems, setPinnedItems] = useState(
+		localStorage.getItem('pinnedItems')
+			? JSON.parse(localStorage.getItem('pinnedItems'))
+			: []
+	);
+	const [selectedRepos, setSelectedRepos] = useState(
+		localStorage.getItem('selectedRepos')
+			? JSON.parse(localStorage.getItem('selectedRepos'))
+			: []
+	);
+	const { loading, data, error } = useQuery(GET_PRS, {
+		variables: {
+			login: `${username}`,
+		},
+		// pollInterval: 40000, //todo uncomment
+	});
 
-  const {
-    loading: reposLoading,
-    data: reposData,
-    error: reposError
-  } = useQuery(GET_REPOS, {
-    variables: {
-      login: `${username}`
-    }
-  });
+	const {
+		loading: reposLoading,
+		data: reposData,
+		error: reposError,
+	} = useQuery(GET_REPOS, {
+		variables: {
+			login: `${username}`,
+		},
+	});
 
-  let options = [];
+	let options = [];
 
-  if (reposData) {
-    options = reposData.user.repositories.nodes.map(element => {
-      return { value: element.id, label: element.nameWithOwner };
-    });
-  }
+	if (reposData) {
+		options = reposData.user.repositories.nodes.map(element => {
+			return { value: element.id, label: element.nameWithOwner };
+		});
+	}
 
-  if (error) return <p>Error</p>; // todo make an error page
-  if (loading) return <p>loading</p>; //todo add stylying
+	if (error) return <p>Error</p>; // todo make an error page
+	if (loading) return <p>loading</p>; //todo add stylying
 
-  const allPRs = data ? mergePRs(data) : [];
-  const filteredByRepos = filterByRepos(allPRs, selectedRepos);
+	const allPRs = data ? mergePRs(data) : [];
+	const filteredByRepos = filterByRepos(allPRs, selectedRepos);
 
-  const notPinned = filteredByRepos.filter(
-    element => !pinnedItems.includes(element.id)
-  );
-  const pinned = filteredByRepos.filter(element =>
-    pinnedItems.includes(element.id)
-  );
-  const prs = [...pinned, ...notPinned];
+	const notPinned = filteredByRepos.filter(
+		element => !pinnedItems.includes(element.id)
+	);
+	const pinned = filteredByRepos.filter(element =>
+		pinnedItems.includes(element.id)
+	);
+	const prs = [...pinned, ...notPinned];
 
-  return (
-    <div className={cx('Dashboard', className)}>
-      <div className="Dashboard-title">Your PRs dashboard</div>
-      <Filter
-        options={options}
-        className="Dashboard-filter"
-        value={selectedRepos}
-        placeholder="Select your repos..."
-        onChange={value => {
-          setSelectedRepos(value);
-          localStorage.setItem('selectedRepos', JSON.stringify(selectedRepos));
-        }}
-      />
-      <PrList
-        prs={prs}
-        setPinnedItems={setPinnedItems}
-        className={'Dashboard-list'}
-      />
-    </div>
-  );
+	return (
+		<div className={cx('Dashboard', className)}>
+			<div className='Dashboard-title'>Your PRs dashboard</div>
+			<Filter
+				options={options}
+				className='Dashboard-filter'
+				value={selectedRepos}
+				placeholder='Select your repos...'
+				onChange={value => {
+					setSelectedRepos(value);
+					localStorage.setItem(
+						'selectedRepos',
+						JSON.stringify(selectedRepos)
+					);
+				}}
+			/>
+			<PrList
+				prs={prs}
+				setPinnedItems={setPinnedItems}
+				className={'Dashboard-list'}
+			/>
+		</div>
+	);
 }
 
 export default Dashboard;

--- a/client/src/Dashboard/utils.js
+++ b/client/src/Dashboard/utils.js
@@ -1,0 +1,30 @@
+export function getPRFromRepos(repos) {
+  return repos.reduce((acc, element) => {
+    return acc.concat(element.pullRequests.nodes);
+  }, []);
+}
+
+export function getReposFromOrgs(orgs) {
+  return orgs.reduce(
+    (acc, element) => acc.concat(element.repositories.nodes),
+    []
+  );
+}
+
+export function mergePRs(queryData) {
+  const userReposPRs = getPRFromRepos(queryData.user.repositories.nodes);
+  const orgsReposPRs = getPRFromRepos(
+    getReposFromOrgs(queryData.user.organizations.nodes)
+  );
+
+  return [...userReposPRs, ...orgsReposPRs].sort(
+    (a, b) => new Date(b.updatedAt) - new Date(a.updatedAt)
+  );
+}
+export function filterByRepos(allPRs, repos) {
+  return Array.isArray(repos) && repos.length > 0
+    ? allPRs.filter(element =>
+        repos.some(repo => repo.value === element.repository.id)
+      )
+    : allPRs;
+}

--- a/client/src/Dashboard/utils.js
+++ b/client/src/Dashboard/utils.js
@@ -1,30 +1,30 @@
 export function getPRFromRepos(repos) {
-  return repos.reduce((acc, element) => {
-    return acc.concat(element.pullRequests.nodes);
-  }, []);
+	return repos.reduce((acc, element) => {
+		return acc.concat(element.pullRequests.nodes);
+	}, []);
 }
 
 export function getReposFromOrgs(orgs) {
-  return orgs.reduce(
-    (acc, element) => acc.concat(element.repositories.nodes),
-    []
-  );
+	return orgs.reduce(
+		(acc, element) => acc.concat(element.repositories.nodes),
+		[]
+	);
 }
 
 export function mergePRs(queryData) {
-  const userReposPRs = getPRFromRepos(queryData.user.repositories.nodes);
-  const orgsReposPRs = getPRFromRepos(
-    getReposFromOrgs(queryData.user.organizations.nodes)
-  );
+	const userReposPRs = getPRFromRepos(queryData.user.repositories.nodes);
+	const orgsReposPRs = getPRFromRepos(
+		getReposFromOrgs(queryData.user.organizations.nodes)
+	);
 
-  return [...userReposPRs, ...orgsReposPRs].sort(
-    (a, b) => new Date(b.updatedAt) - new Date(a.updatedAt)
-  );
+	return [...userReposPRs, ...orgsReposPRs].sort(
+		(a, b) => new Date(b.updatedAt) - new Date(a.updatedAt)
+	);
 }
 export function filterByRepos(allPRs, repos) {
-  return Array.isArray(repos) && repos.length > 0
-    ? allPRs.filter(element =>
-        repos.some(repo => repo.value === element.repository.id)
-      )
-    : allPRs;
+	return Array.isArray(repos) && repos.length > 0
+		? allPRs.filter(element =>
+				repos.some(repo => repo.value === element.repository.id)
+		  )
+		: allPRs;
 }


### PR DESCRIPTION
First of all, thank you so much for this utility. I'm trying to find something to find all PRs across all the repos I usually contribute to.
Concretely, I'd like to use the app with the GHE and I'm collaborator in more than 5 repos in different organizations.
My protocol when I open a PR is to work in a branch on the same origin without for the repo. This is why I propose these changes.
Please, let me know your thoughts and congrats for the app. Excited to implement it on my daily basis workflow 😃

## Proposal
### Show PRs from user organizations
When a user usually works within organizations, they usually are assigned to different PRs across different organizations. You don't need to mandatory open a PR from your fork (previous approach), you can open a PR on an organization repository from a branch on the same origin.
> For example, open a pull request: 
> base repository `company/gitrank` base `master` <- head repository `company/gitrank` base `dev`

For this reason, I'd like to suggest to add to Gitrank the possibility to fetch all the PRs from the different organizations where you belong to.
### Show only PR opens
Due to the limitation to not have paginations, we lose some old PRs we want to track. For example, if we have a 1-month-old PR and we've close in the last month more than 100PRs we will lose it. So I'd like to propose to show only PR open. This could help me to track older PRs.

## Code changes
* Add a new endpoint on the GraphQL `organizations()` where we will fetch the organizations -> repos -> PRs
* Add a filter by `states = OPEN` to the `pullRequest` GraphQL query schema.
* Reuser the repositories query schema to ensure we bring the same information about the repositories
* Reorder imports
* Move the logic to massage the data to the component `util` file
* Reduce the loops over the data to massage it
* Remove credentials from the `Dashboard` state because they are not used
* Add [prettier config file](https://prettier.io/docs/en/configuration.html) to avoid collaboration format conflicts (the format is IDE and environment agnostic)

## Screenshots
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/5699976/75931627-bf300000-5e75-11ea-9ee5-ab697f91df99.gif"</td>
    <td><img src="https://user-images.githubusercontent.com/5699976/75931222-bc80db00-5e74-11ea-8223-4714e09cd198.gif" /></td>
  </tr>
</table>
